### PR TITLE
Single source the project description in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# Compute the factorial
- 
 This crate provides some convenient and safe methods to compute the factorial with an efficient method. More precisely it uses the prime swing algorithm to compute the factorial. See [this paper](https://oeis.org/A000142/a000142.pdf) for more detail.
 
-It can compute the factorial in $O(n (\log{n} \cdot \log{\log {n}})^2)$ operations of multiplication. The time complexity of this algorithm depends on the time complexity of the multiplication algorithm used.
+It can compute the factorial in `O(n (log n loglog n)^2)` operations of multiplication. The time complexity of this algorithm depends on the time complexity of the multiplication algorithm used.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,4 @@
-//! # Compute the factorial
-//!
-//! This crate provides some convenient and safe methods to compute the
-//! factorial and related functions the most naive way possible.
-//!
-//! They are not necessarily the fastest versions: there are prime sieve methods that
-//! compute the factorial in `O(n (log n loglog n)^2)`. Patches are welcome.
+#![doc = include_str!("../README.md")]
 
 use num_traits::{CheckedMul, FromPrimitive, ToPrimitive, Unsigned};
 use primal_sieve::Sieve;


### PR DESCRIPTION
The project description provided by the README is dynamically used as the preamble in the crate documentation. This makes `README.md` the single source for the preamble so that the crate documentation always remains in sync with it.